### PR TITLE
Add FAQ section to credibility component

### DIFF
--- a/src/components/Benefits.tsx
+++ b/src/components/Benefits.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CheckCircle, Lightbulb, Users, TrendingUp } from 'lucide-react';
+import { CheckCircle, Lightbulb, Users } from 'lucide-react';
 
 const Benefits = () => {
   const discoveries = [

--- a/src/components/Bonus.tsx
+++ b/src/components/Bonus.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Gift, Clock, BookOpen, Video } from 'lucide-react';
+import { Gift, Clock, BookOpen } from 'lucide-react';
 
 const Bonus = () => {
   const bonuses = [

--- a/src/components/CTA.tsx
+++ b/src/components/CTA.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
-import { ShieldCheck, Clock, Users } from 'lucide-react';
 
-const CTA = () => {
+export default function CTA() {
   return (
     <section className="bg-gradient-to-r from-pink-500 to-red-500 py-16">
       <div className="container mx-auto px-4 text-center">
         {/* CTA Image */}
         <div className="mb-8">
-          <img 
-            src="https://i.imgur.com/5H6yvst.png=400" 
+          <img
+            src="https://i.imgur.com/5H6yvst.png=400"
             alt="Mãe feliz com celular recebendo conteúdo digital"
             className="w-30 h-30 mx-auto rounded-full object-cover"
           />
@@ -22,8 +21,8 @@ const CTA = () => {
           {/* Guarantees */}
           <div className="grid md:grid-cols-3 gap-6 mb-8">
             <div className="bg-white bg-opacity-10 p-6 rounded-xl">
-              <img 
-                src="https://i.imgur.com/fsySJjQ.png=400" 
+              <img
+                src="https://i.imgur.com/fsySJjQ.png=400"
                 alt="Selo de garantia e proteção"
                 className="w-30 h-30 mx-auto mb-3 rounded-full object-cover"
               />
@@ -31,8 +30,8 @@ const CTA = () => {
               <p className="text-white opacity-90">30 dias para testar. Não gostou? Devolvemos 100%</p>
             </div>
             <div className="bg-white bg-opacity-10 p-6 rounded-xl">
-              <img 
-                src="https://i.imgur.com/4X596s6.png" 
+              <img
+                src="https://i.imgur.com/4X596s6.png"
                 alt="Acesso imediato"
                 className="w-30 h-30 mx-auto mb-3 rounded-full object-cover"
               />
@@ -40,8 +39,8 @@ const CTA = () => {
               <p className="text-white opacity-90">Receba tudo no seu email em menos de 2 minutos</p>
             </div>
             <div className="bg-white bg-opacity-10 p-6 rounded-xl">
-              <img 
-                src="https://i.imgur.com/qtTjFya.png" 
+              <img
+                src="https://i.imgur.com/qtTjFya.png"
                 alt="Vagas limitadas"
                 className="w-30 h-30 mx-auto mb-3 rounded-full object-cover"
               />
@@ -54,7 +53,7 @@ const CTA = () => {
           <div className="bg-yellow-400 text-black p-6 rounded-xl">
             <h3 className="text-2xl font-bold mb-2">⚠️ ATENÇÃO: OFERTA LIMITADA</h3>
             <p className="text-lg font-medium">
-              Devido ao valor promocional, essa condição está disponível apenas para as 
+              Devido ao valor promocional, essa condição está disponível apenas para as
               <span className="font-bold"> primeiras 10 gestantes</span> que acessarem o conteúdo.
             </p>
           </div>
@@ -62,6 +61,4 @@ const CTA = () => {
       </div>
     </section>
   );
-};
-
-export default CTA;
+}

--- a/src/components/Credibility.tsx
+++ b/src/components/Credibility.tsx
@@ -1,6 +1,34 @@
 import React from 'react';
 import { Award, Users, BookOpen, Star } from 'lucide-react';
 
+const faqs: { question: string; answer: string }[] = [
+  {
+    question: 'Como recebo o Método dos 21 Nutrientes após a compra?',
+    answer:
+      'O acesso chega imediatamente no seu e-mail assim que o pagamento é confirmado, permitindo que você entre na plataforma e consulte todo o conteúdo na mesma hora.',
+  },
+  {
+    question: 'Por quanto tempo terei acesso ao conteúdo?',
+    answer:
+      'O acesso é vitalício. Você realiza um único pagamento e pode revisar as orientações sempre que precisar durante a gestação e até no pós-parto.',
+  },
+  {
+    question: 'Serve para todas as fases da gestação?',
+    answer:
+      'Sim. O método está organizado por trimestre gestacional, com listas de mercado, cardápios e orientações específicas para cada fase.',
+  },
+  {
+    question: 'Vou precisar comprar alimentos caros ou suplementos importados?',
+    answer:
+      'Não. Todo o plano é focado em comida de verdade acessível, com substituições econômicas e ingredientes que você encontra facilmente no mercado.',
+  },
+  {
+    question: 'E se eu tiver restrições alimentares ou enjoos?',
+    answer:
+      'Você recebe opções de substituição e cardápios adaptáveis para as restrições mais comuns, além de sugestões para lidar com enjoos e aversões típicas da gestação.',
+  },
+];
+
 const Credibility = () => {
   return (
     <section className="bg-white py-16">
@@ -48,9 +76,25 @@ const Credibility = () => {
             </div>
           </div>
 
+          {/* Perguntas Frequentes */}
+          <div className="bg-white p-8 rounded-2xl border border-blue-100 shadow-sm mb-12 text-left">
+            <h3 className="text-2xl font-bold text-gray-900 mb-6 text-center">Perguntas Frequentes</h3>
+            <dl className="space-y-6">
+              {faqs.map((faq) => (
+                <div
+                  key={faq.question}
+                  className="bg-blue-50 p-6 rounded-xl border border-blue-100"
+                >
+                  <dt className="text-lg font-semibold text-gray-800">{faq.question}</dt>
+                  <dd className="text-gray-600 mt-2 leading-relaxed">{faq.answer}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+
           {/* Final Warning */}
           <div className="bg-gray-800 text-white p-8 rounded-2xl">
-            <h3 className="text-2xl font-bold mb-4 text-yellow-400">     
+            <h3 className="text-2xl font-bold mb-4 text-yellow-400">
             </h3>
             <p className="text-lg mb-4">
               Tem mãe gastando mais de <span className="font-bold text-red-400">R$300 por mês</span> em suplemento 


### PR DESCRIPTION
## Summary
- add the stakeholder Perguntas Frequentes content to the credibility section with an accessible FAQ layout
- match the existing visual system for spacing, typography, and colors so the FAQ blends with the rest of the section
- clean up unused icon imports and adjust the CTA component export so eslint passes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc93be5b48833392b99e0b760b05fe